### PR TITLE
update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,16 +2,16 @@ lazy val root = (project in file("."))
   .settings(
     organization := "org.scalikejdbc",
     name := "csvquery",
-    version := "1.3.0",
-    scalaVersion := "2.11.8",
-    crossScalaVersions := Seq("2.10.6", "2.11.8"),
+    version := "1.4.0",
+    scalaVersion := "2.12.0",
+    crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0"),
     libraryDependencies ++= Seq(
-      "com.h2database"       %  "h2"              % "1.4.191",
-      "org.scalikejdbc"      %% "scalikejdbc"     % "2.4.0",
-      "org.skinny-framework" %% "skinny-orm"      % "2.1.0"   % "provided",
-      "ch.qos.logback"       %  "logback-classic" % "1.1.7"   % "provided",
-      "org.skinny-framework" %  "skinny-logback"  % "1.0.9"   % "test",
-      "org.scalatest"        %% "scalatest"       % "2.2.6"   % "test"
+      "com.h2database"       %  "h2"              % "1.4.193",
+      "org.scalikejdbc"      %% "scalikejdbc"     % "2.5.0",
+      "org.skinny-framework" %% "skinny-orm"      % "2.3.0-M1" % "provided",
+      "ch.qos.logback"       %  "logback-classic" % "1.1.7"    % "provided",
+      "org.skinny-framework" %  "skinny-logback"  % "1.0.9"    % "test",
+      "org.scalatest"        %% "scalatest"       % "3.0.0"    % "test"
     ),
     parallelExecution in Test := false,
     logBuffered in Test := false,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype"         % "1.0")
 addSbtPlugin("com.jsuereth"     % "sbt-pgp"              % "1.0.0")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates"          % "0.1.10")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
-addSbtPlugin("org.scoverage"    % "sbt-scoverage"        % "1.3.5")
+addSbtPlugin("org.scoverage"    % "sbt-scoverage"        % "1.5.0")
 addSbtPlugin("org.scoverage"    % "sbt-coveralls"        % "1.0.0")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")


### PR DESCRIPTION
I make this pull request because I want to use csvquery with scalikejdbc 2.5.

However, [skinny-orm is still M1](https://github.com/scalikejdbc/csvquery/compare/master...NoriakiHoriuchi:feature/scalikejdbc2.5#diff-fdc3abdfd754eeb24090dbd90aeec2ceR11), so should I wait for skinny-orm 2.3.0 final?
